### PR TITLE
Sort threads to run slowest group first

### DIFF
--- a/lib/test-suites.js
+++ b/lib/test-suites.js
@@ -82,6 +82,9 @@ function distributeTestsByWeight(testSuitePaths) {
     threads[0].list.push(key);
     threads[0].weight += +value;
   }
+  
+  // Run slowest group first
+  threads.sort((a, b) => b.weight - a.weight);
 
   return threads;
 }


### PR DESCRIPTION
Since there is a delay when starting the Cypress instances, we want to start the slowest group first in order to have it finish as early as possible.